### PR TITLE
set nftsCount mandatory param for getting NFTs from API functions

### DIFF
--- a/src/common/services/elrond-communication/elrond-api.service.ts
+++ b/src/common/services/elrond-communication/elrond-api.service.ts
@@ -442,15 +442,11 @@ export class ElrondApiService {
   async getAllNftsByCollectionAfterNonce(
     collection: string,
     fields: string = 'identifier,nonce,timestamp',
-    startNonce?: number,
+    maxNftsCount: number,
+    startNonce: number = 1,
     endNonce: number = constants.nftsCountThresholdForTraitAndRarityIndexing,
-    maxNftsCount?: number,
   ): Promise<Nft[]> {
     const batchSize = constants.getNftsFromApiBatchSize;
-
-    if (!maxNftsCount) {
-      maxNftsCount = await this.getCollectionNftsCount(collection);
-    }
 
     if (maxNftsCount < batchSize) {
       const query = new AssetsQuery()
@@ -466,7 +462,7 @@ export class ElrondApiService {
     let nfts: Nft[] = [];
     let batch: Nft[] = [];
 
-    let lastEnd = startNonce ?? 0;
+    let lastEnd = startNonce ? startNonce - 1 : 0;
 
     do {
       const start = lastEnd + 1;
@@ -505,18 +501,14 @@ export class ElrondApiService {
     collection: string,
     fields: string = 'identifier,nonce,timestamp',
     action: (nfts: Nft[]) => Promise<boolean | any>,
-    startNonce?: number,
+    collectionNftsCount: number,
+    startNonce: number = 1,
     endNonce: number = constants.nftsCountThresholdForTraitAndRarityIndexing,
-    collectionNftsCount?: number,
   ): Promise<void> {
     const batchSize = constants.getNftsFromApiBatchSize;
 
-    if (!collectionNftsCount) {
-      collectionNftsCount = await this.getCollectionNftsCount(collection);
-    }
-
     let nftsCount = 0;
-    let lastEnd = startNonce ?? 0;
+    let lastEnd = startNonce ? startNonce - 1 : 0;
     let actionResult: boolean;
 
     do {
@@ -722,10 +714,7 @@ export class ElrondApiService {
   }
 
   async getElrondStats(): Promise<ElrondStats> {
-    const stats = await this.doGetGeneric(
-      this.getElrondStats.name,
-      'stats',
-    );
+    const stats = await this.doGetGeneric(this.getElrondStats.name, 'stats');
     return new ElrondStats(stats);
   }
 

--- a/src/modules/nft-traits/nft-traits.service.ts
+++ b/src/modules/nft-traits/nft-traits.service.ts
@@ -120,6 +120,7 @@ export class NftTraitsService {
       ] = await Promise.all([
         this.getAllCollectionNftsFromAPI(
           collection,
+          nftsCount,
           lastNonce,
           lastNonce + batchSize,
         ),
@@ -419,6 +420,7 @@ export class NftTraitsService {
 
   private async getAllCollectionNftsFromAPI(
     collectionTicker: string,
+    collectionNftsCount: number,
     startNonce?: number,
     endNonce?: number,
   ): Promise<NftTraits[]> {
@@ -426,6 +428,7 @@ export class NftTraitsService {
       const res = await this.apiService.getAllNftsByCollectionAfterNonce(
         collectionTicker,
         'identifier,nonce,timestamp,metadata',
+        collectionNftsCount,
         startNonce,
         endNonce,
       );


### PR DESCRIPTION
2 functions that get NFTs from API were requesting collectionNftsCount for every batch/request

fix: made the nftsCount a mandatory param