### PR TITLE
Services 957 fix burn events for traits rarities and scam

### DIFF
--- a/src/common/services/caching/entities/cache.info.ts
+++ b/src/common/services/caching/entities/cache.info.ts
@@ -118,4 +118,9 @@ export class CacheInfo {
     key: 'mostLikedAssets',
     ttl: TimeConstants.oneDay,
   };
+
+  static CollectionTypes: CacheInfo = {
+    key: 'collectionType',
+    ttl: TimeConstants.oneHour,
+  };
 }


### PR DESCRIPTION
- for BURN events, check if NFT/SFT before updating traits, rarities or scamInfo; 
- check if no more SFT quantity before deleting from rarities or scamInfo DB;
- cache collection type & wait 1 more second for traits and rarities so we'll have just 1 API call made by scamInfo function;