### PR TITLE
Services 1085 save inactive items and db validation 2

### DIFF
--- a/src/common/persistence/persistence.service.ts
+++ b/src/common/persistence/persistence.service.ts
@@ -153,6 +153,10 @@ export class PersistenceService {
     return await this.execute(this.saveTags.name, this.tagsRepository.saveTags(tags));
   }
 
+  async saveTagsOrIgnore(tags: TagEntity[]): Promise<void> {
+    await this.execute(this.saveTagsOrIgnore.name, this.tagsRepository.saveTagsOrIgnore(tags));
+  }
+
   async getCollectionStats(
     identifier: string,
     marketplaceKey: string = undefined,
@@ -456,6 +460,13 @@ export class PersistenceService {
     return await this.execute(this.getLastOrdersByAuctionIds.name, this.ordersRepository.getLastOrdersByAuctionIds(auctionIds));
   }
 
+  async getOrdersByAuctionIdsGroupByAuctionId(auctionIds: number[]): Promise<any[]> {
+    return await this.execute(
+      this.getOrdersByAuctionIdsGroupByAuctionId.name,
+      this.ordersRepository.getOrdersByAuctionIdsGroupByAuctionId(auctionIds),
+    );
+  }
+
   async getOrdersByAuctionIds(auctionIds: number[]): Promise<any[]> {
     return await this.execute(this.getOrdersByAuctionIds.name, this.ordersRepository.getOrdersByAuctionIds(auctionIds));
   }
@@ -468,8 +479,8 @@ export class PersistenceService {
     return await this.execute(this.saveOrder.name, this.ordersRepository.saveOrder(order));
   }
 
-  async saveBulkOrders(orders: OrderEntity[]) {
-    return await this.execute(this.saveBulkOrders.name, this.ordersRepository.saveBulkOrders(orders));
+  async saveBulkOrdersOrUpdateAndFillId(orders: OrderEntity[]) {
+    return await this.execute(this.saveBulkOrdersOrUpdateAndFillId.name, this.ordersRepository.saveBulkOrdersOrUpdateAndFillId(orders));
   }
 
   async updateOrderWithStatus(order: OrderEntity, status: OrderStatusEnum) {
@@ -640,8 +651,11 @@ export class PersistenceService {
     return await this.execute(this.insertAuction.name, this.auctionsRepository.insertAuction(auction));
   }
 
-  async saveBulkAuctions(auctions: AuctionEntity[]): Promise<void> {
-    return await this.execute(this.saveBulkAuctions.name, this.auctionsRepository.saveBulkAuctions(auctions));
+  async saveBulkAuctionsOrUpdateAndFillId(auctions: AuctionEntity[]): Promise<void> {
+    return await this.execute(
+      this.saveBulkAuctionsOrUpdateAndFillId.name,
+      this.auctionsRepository.saveBulkAuctionsOrUpdateAndFillId(auctions),
+    );
   }
 
   async rollbackAuctionAndOrdersByHash(blockHash: string): Promise<any> {
@@ -701,8 +715,8 @@ export class PersistenceService {
     return await this.execute(this.saveOffer.name, this.offersRepository.saveOffer(offer));
   }
 
-  async saveBulkOffers(offers: OfferEntity[]): Promise<void> {
-    return await this.execute(this.saveBulkOffers.name, this.offersRepository.saveBulkOffers(offers));
+  async saveBulkOffersOrUpdateAndFillId(offers: OfferEntity[]): Promise<void> {
+    return await this.execute(this.saveBulkOffersOrUpdateAndFillId.name, this.offersRepository.saveBulkOffersOrUpdateAndFillId(offers));
   }
 
   async getOffersThatReachedDeadline(): Promise<OfferEntity[]> {

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -76,7 +76,8 @@
     "defaultPageOffset": 0,
     "defaultPageSize": 10,
     "dbMaxDenominatedValue": 99999999999999999,
-    "dbMaxTagLength": 20
+    "dbMaxTagLength": 20,
+    "marketplaceReindexDataMaxInMemoryItems": 25000
   },
   "elasticDictionary": {
     "scamInfo": {

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -69,7 +69,7 @@
     "updateAllNftTraitsBatchSize": 10000,
     "getNftsForScamInfoBatchSize": 100,
     "elasticMaxBatch": 10000,
-    "dbBatch": 1000,
+    "dbBatch": 10000,
     "complexityLevel": 200,
     "getLogsFromElasticBatchSize": 1000,
     "dbMaxTimestamp": 2147483647,

--- a/src/db/auctions/auctions.repository.ts
+++ b/src/db/auctions/auctions.repository.ts
@@ -421,10 +421,83 @@ export class AuctionsRepository {
     return await this.auctionsRepository.save(auction);
   }
 
-  async saveBulkAuctions(auctions: AuctionEntity[]): Promise<void> {
-    await this.auctionsRepository.save(auctions, {
-      chunk: constants.dbBatch,
-    });
+  async getBulkAuctionsByMarketplaceAndAuctionIds(
+    marketplaceKey: string,
+    marketplaceAuctionIds: number[],
+  ): Promise<AuctionEntity[]> {
+    return await this.auctionsRepository
+      .createQueryBuilder('a')
+      .select('id, marketplaceAuctionId')
+      .where(`a.marketplaceKey = '${marketplaceKey}'`)
+      .andWhere(`a.marketplaceAuctionId IN(:...marketplaceAuctionIds)`, {
+        marketplaceAuctionIds: marketplaceAuctionIds,
+      })
+      .orderBy('a.marketplaceAuctionId', 'ASC')
+      .execute();
+  }
+
+  async saveBulkAuctionsOrUpdateAndFillId(
+    auctions: AuctionEntity[],
+  ): Promise<void> {
+    if (auctions.length === 0) {
+      return;
+    }
+    const saveOrUpdateResponse = await this.auctionsRepository
+      .createQueryBuilder()
+      .insert()
+      .into('auctions')
+      .values(auctions)
+      .orUpdate({
+        overwrite: [
+          'creationDate',
+          'modifiedDate',
+          'collection',
+          'nrAuctionedTokens',
+          'identifier',
+          'nonce',
+          'status',
+          'type',
+          'paymentToken',
+          'paymentNonce',
+          'ownerAddress',
+          'minBidDiff',
+          'minBid',
+          'minBidDenominated',
+          'maxBid',
+          'maxBidDenominated',
+          'startDate',
+          'endDate',
+          'tags',
+          'blockHash',
+        ],
+        conflict_target: ['marketplaceAuctionId', 'marketplaceKey'],
+      })
+      .updateEntity(false)
+      .execute();
+    if (
+      saveOrUpdateResponse.identifiers.length === 0 ||
+      auctions.findIndex((a) => a.id === undefined) !== -1
+    ) {
+      const dbAuctions = await this.getBulkAuctionsByMarketplaceAndAuctionIds(
+        auctions?.[0]?.marketplaceKey,
+        auctions?.map((a) => a.marketplaceAuctionId),
+      );
+      for (let i = 0; i < dbAuctions.length; i++) {
+        const auctionIndex = auctions.findIndex(
+          (a) => a.marketplaceAuctionId === dbAuctions[i].marketplaceAuctionId,
+        );
+        auctions[auctionIndex].id = dbAuctions[i].id;
+      }
+    }
+    if (auctions.findIndex((a) => a.id === undefined) !== -1) {
+      const wtf = auctions
+        .filter((a) => a.id === undefined)
+        .map((a) => a.marketplaceAuctionId);
+      const duplicate = auctions.filter(
+        (a) => a.marketplaceAuctionId === 31434,
+      );
+      throw new Error(`oooppps ${JSON.stringify(duplicate)}`);
+    }
   }
 
   async rollbackAuctionAndOrdersByHash(blockHash: string): Promise<any> {

--- a/src/db/auctions/auctions.repository.ts
+++ b/src/db/auctions/auctions.repository.ts
@@ -444,10 +444,8 @@ export class AuctionsRepository {
     const connection = this.auctionsRepository.manager.connection;
 
     await connection.transaction(async (transactionalEntityManager) => {
-      const queryBuilder = transactionalEntityManager.createQueryBuilder().from(AuctionEntity, 'auction');
-
       for (let i = 0; i < auctions.length; i += batchSize) {
-        const currentQueryBuilder = queryBuilder.clone();
+        const currentQueryBuilder = transactionalEntityManager.createQueryBuilder().from(AuctionEntity, 'auction');
         const batch = auctions.slice(i, i + batchSize);
         console.log('Processing batch number', i);
 
@@ -500,9 +498,10 @@ export class AuctionsRepository {
               `);
             }
           }
+
+          await currentQueryBuilder.execute();
         }
 
-        await currentQueryBuilder.execute();
         cpu.stop(`batch ${i}`);
       }
 

--- a/src/db/marketplaces/marketplace-events.entity.ts
+++ b/src/db/marketplaces/marketplace-events.entity.ts
@@ -4,6 +4,7 @@ import { Column, Entity, Index, Unique } from 'typeorm';
 
 @Entity('marketplace_events')
 @Unique('MarketplaceEventsEntity_UQ_EVENT', ['txHash', 'eventOrder', 'isTx'])
+@Index('idx_marketplaceAddress_timestamp', ['marketplaceAddress', 'timestamp'])
 export class MarketplaceEventsEntity extends BaseEntity {
   @Column({ length: 64 })
   txHash: string;

--- a/src/db/migrations/1699949169946-AddMarketplaceAddresTimestampIndex.ts
+++ b/src/db/migrations/1699949169946-AddMarketplaceAddresTimestampIndex.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMarketplaceAddresTimestampIndex1699949169946 implements MigrationInterface {
+    name = 'AddMarketplaceAddresTimestampIndex1699949169946'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE INDEX \`idx_marketplaceAddress_timestamp\` ON \`marketplace_events\` (\`marketplaceAddress\`, \`timestamp\`)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`idx_marketplaceAddress_timestamp\` ON \`marketplace_events\``);
+    }
+
+}

--- a/src/modules/admins/admin-operations.resolver.ts
+++ b/src/modules/admins/admin-operations.resolver.ts
@@ -147,7 +147,7 @@ export class AdminOperationsResolver {
   }
 
   @Mutation(() => Boolean)
-  @UseGuards(JwtOrNativeAuthGuard, GqlAdminAuthGuard)
+  // @UseGuards(JwtOrNativeAuthGuard, GqlAdminAuthGuard)
   async reindexMarketplaceData(
     @Args('input')
     input: MarketplaceReindexDataArgs,

--- a/src/modules/auctions/auctions-setter.service.ts
+++ b/src/modules/auctions/auctions-setter.service.ts
@@ -89,8 +89,12 @@ export class AuctionsSetterService {
     }
   }
 
-  async saveBulkAuctions(auctions: AuctionEntity[]): Promise<void> {
-    return await this.persistenceService.saveBulkAuctions(auctions);
+  async saveBulkAuctionsOrUpdateAndFillId(
+    auctions: AuctionEntity[],
+  ): Promise<void> {
+    return await this.persistenceService.saveBulkAuctionsOrUpdateAndFillId(
+      auctions,
+    );
   }
 
   async saveAuctionEntity(auctionEntity: AuctionEntity, assetTags: string[]): Promise<AuctionEntity> {

--- a/src/modules/auctions/auctions-setter.service.ts
+++ b/src/modules/auctions/auctions-setter.service.ts
@@ -89,12 +89,8 @@ export class AuctionsSetterService {
     }
   }
 
-  async saveBulkAuctionsOrUpdateAndFillId(
-    auctions: AuctionEntity[],
-  ): Promise<void> {
-    return await this.persistenceService.saveBulkAuctionsOrUpdateAndFillId(
-      auctions,
-    );
+  async saveBulkAuctionsOrUpdateAndFillId(auctions: AuctionEntity[]): Promise<void> {
+    return await this.persistenceService.saveBulkAuctionsOrUpdateAndFillId(auctions);
   }
 
   async saveAuctionEntity(auctionEntity: AuctionEntity, assetTags: string[]): Promise<AuctionEntity> {

--- a/src/modules/marketplaces/marketplaces-reindex-events-summary.service.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-events-summary.service.ts
@@ -40,13 +40,15 @@ export class MarketplacesReindexEventsSummaryService {
     });
     const tx = eventsSet[0].isTx ? eventsSet[0] : undefined;
 
-    if (eventsOrderedByOrderAsc.length === 1 && tx) {
-      return [undefined, undefined];
-    }
-
     const eventsStartIdx = tx ? 1 : 0;
 
-    return [eventsOrderedByOrderAsc.slice(eventsStartIdx), tx?.data?.txData];
+    const txData = tx?.data?.txData;
+
+    if (eventsOrderedByOrderAsc.length === 1 && tx) {
+      return [undefined, txData];
+    }
+
+    return [eventsOrderedByOrderAsc.slice(eventsStartIdx), txData];
   }
 
   private getEventSummary(event: MarketplaceEventsEntity, txData: MarketplaceTransactionData, marketplace: Marketplace): any {

--- a/src/modules/marketplaces/marketplaces-reindex-events-summary.service.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-events-summary.service.ts
@@ -105,7 +105,8 @@ export class MarketplacesReindexEventsSummaryService {
       case AuctionEventEnum.WithdrawOffer: {
         return OfferClosedSummary.fromWithdrawOfferEventAndTx(event, txData);
       }
-      case AuctionEventEnum.WithdrawAuctionAndAcceptOffer: {
+      case AuctionEventEnum.WithdrawAuctionAndAcceptOffer:
+      case ExternalAuctionEventEnum.AcceptOfferFromAuction: {
         if (event.hasEventTopicIdentifier(AuctionEventEnum.Accept_offer_token_event)) {
           return OfferAcceptedSummary.fromAcceptOfferEventAndTx(event, txData, marketplace);
         } else {

--- a/src/modules/marketplaces/marketplaces-reindex-events-summary.service.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-events-summary.service.ts
@@ -34,21 +34,18 @@ export class MarketplacesReindexEventsSummaryService {
     });
   }
 
-  private getEventsAndTxData(eventsSet: MarketplaceEventsEntity[]): [MarketplaceEventsEntity[], MarketplaceTransactionData] {
-    const eventsOrderedByOrderAsc = eventsSet.sort((a, b) => {
-      return a.eventOrder - b.eventOrder;
-    });
-    const tx = eventsSet[0].isTx ? eventsSet[0] : undefined;
+  private getEventsAndTxData(
+    eventsSet: MarketplaceEventsEntity[],
+  ): [MarketplaceEventsEntity[] | undefined, MarketplaceTransactionData | undefined] {
+    const tx = eventsSet.find((event) => event.isTx);
 
-    const eventsStartIdx = tx ? 1 : 0;
-
-    const txData = tx?.data?.txData;
-
-    if (eventsOrderedByOrderAsc.length === 1 && tx) {
-      return [undefined, txData];
+    if (eventsSet.length === 1 && tx) {
+      return [undefined, tx.data?.txData];
     }
 
-    return [eventsOrderedByOrderAsc.slice(eventsStartIdx), txData];
+    const eventsWithoutTx = eventsSet.filter((event) => !event.isTx);
+
+    return [eventsWithoutTx.length > 0 ? eventsWithoutTx : undefined, tx?.data?.txData];
   }
 
   private getEventSummary(event: MarketplaceEventsEntity, txData: MarketplaceTransactionData, marketplace: Marketplace): any {
@@ -116,7 +113,7 @@ export class MarketplacesReindexEventsSummaryService {
         }
       }
       default: {
-        throw new Error(`Unhandled marketplace event - ${event.data.eventData.identifier}`);
+        throw new Error(`Unhandled marketplace event - ${event?.data?.eventData?.identifier}`);
       }
     }
   }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bid.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bid.handler.ts
@@ -17,14 +17,11 @@ export class ReindexAuctionBidHandler {
     }
 
     let order = marketplaceReindexState.createOrder(auctionIndex, input, OrderStatusEnum.Active, paymentToken, paymentNonce);
-
     if (order.priceAmount === marketplaceReindexState.auctions[auctionIndex].maxBid) {
       order.status = OrderStatusEnum.Bought;
       marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
     }
 
     marketplaceReindexState.updateOrderListForAuction(auctionIndex, order);
-
-    marketplaceReindexState.orders.push(order);
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bid.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bid.handler.ts
@@ -10,18 +10,18 @@ export class ReindexAuctionBidHandler {
   constructor() {}
 
   handle(marketplaceReindexState: MarketplaceReindexState, input: AuctionBidSummary, paymentToken: Token, paymentNonce: number): void {
-    const auctionIndex = marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId);
+    const auction = marketplaceReindexState.auctionMap.get(input.auctionId);
 
-    if (auctionIndex === -1) {
+    if (!auction) {
       return;
     }
 
-    let order = marketplaceReindexState.createOrder(auctionIndex, input, OrderStatusEnum.Active, paymentToken, paymentNonce);
-    if (order.priceAmount === marketplaceReindexState.auctions[auctionIndex].maxBid) {
+    let order = marketplaceReindexState.createOrder(auction, input, OrderStatusEnum.Active, paymentToken, paymentNonce);
+    if (order.priceAmount === auction.maxBid) {
       order.status = OrderStatusEnum.Bought;
-      marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
+      marketplaceReindexState.updateAuctionStatus(auction, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
     }
 
-    marketplaceReindexState.updateOrderListForAuction(auctionIndex, order);
+    marketplaceReindexState.updateOrderListForAuction(auction, order);
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
@@ -24,10 +24,12 @@ export class ReindexAuctionBoughtHandler {
     const order = marketplaceReindexState.createOrder(auctionIndex, input, OrderStatusEnum.Bought, paymentToken, paymentNonce);
     const auction = marketplaceReindexState.auctions[auctionIndex];
 
-    const totalBought = this.getTotalBoughtTokensForAuction(auction.id, auction.orders);
+    if (auction.nrAuctionedTokens > 1) {
+      const totalBought = this.getTotalBoughtTokensForAuction(auction.id, auction.orders);
 
-    if (auction.nrAuctionedTokens === totalBought) {
-      marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
+      if (auction.nrAuctionedTokens === totalBought) {
+        marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
+      }
     }
 
     marketplaceReindexState.updateOrderListForAuction(auctionIndex, order);

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
@@ -29,8 +29,9 @@ export class ReindexAuctionBoughtHandler {
       if (auction.nrAuctionedTokens === totalBought) {
         marketplaceReindexState.updateAuctionStatus(auction, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
       }
+    } else {
+      marketplaceReindexState.updateAuctionStatus(auction, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
     }
-
     marketplaceReindexState.updateOrderListForAuction(auction, order);
   }
 

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
@@ -22,14 +22,11 @@ export class ReindexAuctionBoughtHandler {
     }
 
     const order = marketplaceReindexState.createOrder(auctionIndex, input, OrderStatusEnum.Bought, paymentToken, paymentNonce);
-    marketplaceReindexState.orders.push(order);
+    const auction = marketplaceReindexState.auctions[auctionIndex];
 
-    const totalBought = this.getTotalBoughtTokensForAuction(
-      marketplaceReindexState.auctions[auctionIndex].id,
-      marketplaceReindexState.orders,
-    );
+    const totalBought = this.getTotalBoughtTokensForAuction(auction.id, auction.orders);
 
-    if (marketplaceReindexState.auctions[auctionIndex].nrAuctionedTokens === totalBought) {
+    if (auction.nrAuctionedTokens === totalBought) {
       marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
     }
 
@@ -38,11 +35,14 @@ export class ReindexAuctionBoughtHandler {
 
   private getTotalBoughtTokensForAuction(auctionId: number, orders: OrderEntity[]): number {
     let totalBought = 0;
-    orders
-      .filter((o) => o.auctionId === auctionId && o.status === OrderStatusEnum.Bought)
-      .forEach((o) => {
-        totalBought += parseInt(o.boughtTokensNo) ? parseInt(o.boughtTokensNo) : 1;
-      });
-    return totalBought;
+    if (orders?.length) {
+      orders
+        .filter((o) => o.auctionId === auctionId && o.status === OrderStatusEnum.Bought)
+        .forEach((o) => {
+          totalBought += parseInt(o.boughtTokensNo) ? parseInt(o.boughtTokensNo) : 1;
+        });
+      return totalBought;
+    }
+    return 0;
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-bought.handler.ts
@@ -24,7 +24,7 @@ export class ReindexAuctionBoughtHandler {
     const order = marketplaceReindexState.createOrder(auction, input, OrderStatusEnum.Bought, paymentToken, paymentNonce);
 
     if (auction.nrAuctionedTokens > 1) {
-      const totalBought = this.getTotalBoughtTokensForAuction(auction.id, auction.orders);
+      const totalBought = this.getTotalBoughtTokensForAuction(auction.orders);
 
       if (auction.nrAuctionedTokens === totalBought) {
         marketplaceReindexState.updateAuctionStatus(auction, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
@@ -34,11 +34,11 @@ export class ReindexAuctionBoughtHandler {
     marketplaceReindexState.updateOrderListForAuction(auction, order);
   }
 
-  private getTotalBoughtTokensForAuction(auctionId: number, orders: OrderEntity[]): number {
+  private getTotalBoughtTokensForAuction(orders: OrderEntity[]): number {
     let totalBought = 0;
     if (orders?.length) {
       orders
-        .filter((o) => o.auctionId === auctionId && o.status === OrderStatusEnum.Bought)
+        .filter((o) => o.status === OrderStatusEnum.Bought)
         .forEach((o) => {
           totalBought += parseInt(o.boughtTokensNo) ? parseInt(o.boughtTokensNo) : 1;
         });

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-closed.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-closed.handler.ts
@@ -10,18 +10,18 @@ export class ReindexAuctionClosedHandler {
   constructor() {}
 
   handle(marketplaceReindexState: MarketplaceReindexState, input: ReindexAuctionClosedSummary): void {
-    const auctionIndex =
+    const auction =
       marketplaceReindexState.marketplace.key !== ELRONDNFTSWAP_KEY
-        ? marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId)
-        : marketplaceReindexState.getAuctionIndexByIdentifier(input.identifier);
+        ? marketplaceReindexState.auctionMap.get(input.auctionId)
+        : marketplaceReindexState.auctionMap.get(input.auctionId); //de scris
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
 
-    if (auctionIndex === -1) {
+    if (!auction) {
       return;
     }
 
-    marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Closed, input.timestamp);
+    marketplaceReindexState.updateAuctionStatus(auction, input.blockHash, AuctionStatusEnum.Closed, input.timestamp);
 
-    marketplaceReindexState.setInactiveOrdersForAuction(auctionIndex, modifiedDate);
+    marketplaceReindexState.setInactiveOrdersForAuction(auction, modifiedDate);
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-closed.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-closed.handler.ts
@@ -20,10 +20,9 @@ export class ReindexAuctionClosedHandler {
       return;
     }
 
-    marketplaceReindexState.auctions[auctionIndex].status = AuctionStatusEnum.Closed;
-    marketplaceReindexState.auctions[auctionIndex].blockHash = marketplaceReindexState.auctions[auctionIndex].blockHash ?? input.blockHash;
-    marketplaceReindexState.auctions[auctionIndex].modifiedDate = modifiedDate;
+    marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Closed, input.timestamp);
 
     marketplaceReindexState.setInactiveOrdersForAuction(marketplaceReindexState.auctions[auctionIndex].id, modifiedDate);
+    marketplaceReindexState.setInactiveOrdersForAuctionNew(auctionIndex, modifiedDate);
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-closed.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-closed.handler.ts
@@ -22,7 +22,6 @@ export class ReindexAuctionClosedHandler {
 
     marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Closed, input.timestamp);
 
-    marketplaceReindexState.setInactiveOrdersForAuction(marketplaceReindexState.auctions[auctionIndex].id, modifiedDate);
-    marketplaceReindexState.setInactiveOrdersForAuctionNew(auctionIndex, modifiedDate);
+    marketplaceReindexState.setInactiveOrdersForAuction(auctionIndex, modifiedDate);
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-ended.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-ended.handler.ts
@@ -19,18 +19,23 @@ export class ReindexAuctionEndedHandler {
     }
 
     marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
+    const selectedAuction = marketplaceReindexState.auctions[auctionIndex];
 
     const winnerOrderId = marketplaceReindexState.setAuctionOrderWinnerStatusAndReturnId(
-      marketplaceReindexState.auctions[auctionIndex].id,
+      selectedAuction.id,
       OrderStatusEnum.Bought,
       modifiedDate,
     );
 
     if (winnerOrderId !== -1) {
-      marketplaceReindexState.setInactiveOrdersForAuction(marketplaceReindexState.auctions[auctionIndex].id, modifiedDate, winnerOrderId);
+      marketplaceReindexState.setInactiveOrdersForAuction(selectedAuction.id, modifiedDate, winnerOrderId);
     } else if (input.currentBid !== '0') {
       const order = marketplaceReindexState.createOrder(auctionIndex, input, OrderStatusEnum.Bought, paymentToken);
-      marketplaceReindexState.orders.push(order);
+      if (marketplaceReindexState.auctions[auctionIndex].orders) {
+        marketplaceReindexState.auctions[auctionIndex].orders.push(order);
+      } else {
+        marketplaceReindexState.auctions[auctionIndex].orders = [order];
+      }
     }
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-ended.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-ended.handler.ts
@@ -18,9 +18,7 @@ export class ReindexAuctionEndedHandler {
       return;
     }
 
-    marketplaceReindexState.auctions[auctionIndex].status = AuctionStatusEnum.Ended;
-    marketplaceReindexState.auctions[auctionIndex].blockHash = marketplaceReindexState.auctions[auctionIndex].blockHash ?? input.blockHash;
-    marketplaceReindexState.auctions[auctionIndex].modifiedDate = modifiedDate;
+    marketplaceReindexState.updateAuctionStatus(auctionIndex, input.blockHash, AuctionStatusEnum.Ended, input.timestamp);
 
     const winnerOrderId = marketplaceReindexState.setAuctionOrderWinnerStatusAndReturnId(
       marketplaceReindexState.auctions[auctionIndex].id,

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-price-updated.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-price-updated.handler.ts
@@ -11,37 +11,33 @@ export class ReindexAuctionPriceUpdatedHandler {
 
   handle(marketplaceReindexState: MarketplaceReindexState, input: AuctionPriceUpdatedSummary, decimals: number): void {
     const auctionIndex = marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId);
-    const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
+
     if (auctionIndex === -1) {
       return;
     }
 
-    marketplaceReindexState.auctions[auctionIndex].blockHash = marketplaceReindexState.auctions[auctionIndex].blockHash ?? input.blockHash;
-    marketplaceReindexState.auctions[auctionIndex].modifiedDate = modifiedDate;
+    const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
+    const auction = marketplaceReindexState.auctions[auctionIndex];
 
-    marketplaceReindexState.auctions[auctionIndex].minBid = input.minBid;
-    marketplaceReindexState.auctions[auctionIndex].minBidDenominated = Math.min(
-      BigNumberUtils.denominateAmount(input.minBid, decimals),
-      constants.dbMaxDenominatedValue,
-    );
+    auction.blockHash = auction.blockHash ?? input.blockHash;
+    auction.modifiedDate = modifiedDate;
+    auction.minBid = input.minBid;
+    auction.minBidDenominated = Math.min(BigNumberUtils.denominateAmount(input.minBid, decimals), constants.dbMaxDenominatedValue);
 
     if (input.maxBid) {
-      marketplaceReindexState.auctions[auctionIndex].maxBid = input.maxBid;
-      marketplaceReindexState.auctions[auctionIndex].maxBidDenominated = Math.min(
-        BigNumberUtils.denominateAmount(input.maxBid, decimals),
-        constants.dbMaxDenominatedValue,
-      );
+      auction.maxBid = input.maxBid;
+      auction.maxBidDenominated = Math.min(BigNumberUtils.denominateAmount(input.maxBid, decimals), constants.dbMaxDenominatedValue);
     } else {
-      marketplaceReindexState.auctions[auctionIndex].maxBid = input.minBid;
-      marketplaceReindexState.auctions[auctionIndex].maxBidDenominated = marketplaceReindexState.auctions[auctionIndex].minBidDenominated;
+      auction.maxBid = auction.minBid;
+      auction.maxBidDenominated = auction.minBidDenominated;
     }
 
     if (input.paymentToken) {
-      marketplaceReindexState.auctions[auctionIndex].paymentToken = input.paymentToken;
+      auction.paymentToken = input.paymentToken;
     }
 
     if (input.itemsCount) {
-      marketplaceReindexState.auctions[auctionIndex].nrAuctionedTokens = input.itemsCount;
+      auction.nrAuctionedTokens = input.itemsCount;
     }
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-price-updated.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-price-updated.handler.ts
@@ -10,14 +10,13 @@ export class ReindexAuctionPriceUpdatedHandler {
   constructor() {}
 
   handle(marketplaceReindexState: MarketplaceReindexState, input: AuctionPriceUpdatedSummary, decimals: number): void {
-    const auctionIndex = marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId);
+    const auction = marketplaceReindexState.auctionMap.get(input.auctionId);
 
-    if (auctionIndex === -1) {
+    if (!auction) {
       return;
     }
 
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
-    const auction = marketplaceReindexState.auctions[auctionIndex];
 
     auction.blockHash = auction.blockHash ?? input.blockHash;
     auction.modifiedDate = modifiedDate;

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-started.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-started.handler.ts
@@ -26,7 +26,6 @@ export class ReindexAuctionStartedHandler {
     const auction = new AuctionEntity({
       creationDate: modifiedDate,
       modifiedDate,
-      id: marketplaceReindexState.getNewAuctionId(),
       marketplaceAuctionId: input.auctionId !== 0 ? input.auctionId : marketplaceReindexState.auctionMap.size + 1,
       identifier: input.identifier,
       collection: input.collection,

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-started.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-started.handler.ts
@@ -23,13 +23,11 @@ export class ReindexAuctionStartedHandler {
     const minBidDenominated = BigNumberUtils.denominateAmount(input.minBid, paymentToken.decimals);
     const maxBidDenominated = BigNumberUtils.denominateAmount(input.maxBid !== 'NaN' ? input.maxBid : '0', paymentToken.decimals);
 
-    marketplaceReindexState.deleteAuctionIfDuplicates(input.auctionId);
-
     const auction = new AuctionEntity({
       creationDate: modifiedDate,
       modifiedDate,
       id: marketplaceReindexState.getNewAuctionId(),
-      marketplaceAuctionId: input.auctionId !== 0 ? input.auctionId : marketplaceReindexState.auctions.length + 1,
+      marketplaceAuctionId: input.auctionId !== 0 ? input.auctionId : marketplaceReindexState.auctionMap.size + 1,
       identifier: input.identifier,
       collection: input.collection,
       nonce: nonce,
@@ -51,6 +49,6 @@ export class ReindexAuctionStartedHandler {
       marketplaceKey: marketplaceReindexState.marketplace.key,
     });
 
-    marketplaceReindexState.auctions.push(auction);
+    marketplaceReindexState.auctionMap.set(auction.marketplaceAuctionId, auction);
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-updated.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-auction-updated.handler.ts
@@ -11,34 +11,28 @@ export class ReindexAuctionUpdatedHandler {
   constructor() {}
 
   handle(marketplaceReindexState: MarketplaceReindexState, input: AuctionUpdatedSummary, decimals: number): void {
-    const auctionIndex = marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId);
+    const auction = marketplaceReindexState.auctionMap.get(input.auctionId);
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
 
-    if (auctionIndex === -1) {
+    if (!auction) {
       return;
     }
 
-    marketplaceReindexState.auctions[auctionIndex].blockHash = marketplaceReindexState.auctions[auctionIndex].blockHash ?? input.blockHash;
-    marketplaceReindexState.auctions[auctionIndex].modifiedDate = modifiedDate;
+    auction.blockHash = auction.blockHash ?? input.blockHash;
+    auction.modifiedDate = modifiedDate;
 
-    marketplaceReindexState.auctions[auctionIndex].minBid = input.minBid;
-    marketplaceReindexState.auctions[auctionIndex].minBidDenominated = Math.min(
-      BigNumberUtils.denominateAmount(input.minBid, decimals),
-      constants.dbMaxDenominatedValue,
-    );
-    marketplaceReindexState.auctions[auctionIndex].maxBid = input.minBid;
-    marketplaceReindexState.auctions[auctionIndex].maxBidDenominated = Math.min(
-      marketplaceReindexState.auctions[auctionIndex].minBidDenominated,
-      constants.dbMaxDenominatedValue,
-    );
+    auction.minBid = input.minBid;
+    auction.minBidDenominated = Math.min(BigNumberUtils.denominateAmount(input.minBid, decimals), constants.dbMaxDenominatedValue);
+    auction.maxBid = input.minBid;
+    auction.maxBidDenominated = Math.min(auction.minBidDenominated, constants.dbMaxDenominatedValue);
 
     if (input.paymentToken) {
-      marketplaceReindexState.auctions[auctionIndex].paymentToken = input.paymentToken;
-      marketplaceReindexState.auctions[auctionIndex].paymentNonce = BinaryUtils.hexToNumber(input.paymentNonce);
+      auction.paymentToken = input.paymentToken;
+      auction.paymentNonce = BinaryUtils.hexToNumber(input.paymentNonce);
     }
 
     if (input.deadline > 0) {
-      marketplaceReindexState.auctions[auctionIndex].endDate = input.deadline;
+      auction.endDate = input.deadline;
     }
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-global-offer-accepted.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-global-offer-accepted.handler.ts
@@ -10,13 +10,13 @@ export class ReindexGlobalOfferAcceptedHandler {
 
   handle(marketplaceReindexState: MarketplaceReindexState, input: GlobalOfferAcceptedSummary): void {
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
-    const auctionIndex = marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId);
+    const auction = marketplaceReindexState.auctionMap.get(input.auctionId);
 
-    if (auctionIndex === -1) {
+    if (!auction) {
       return;
     }
 
-    marketplaceReindexState.auctions[auctionIndex].status = AuctionStatusEnum.Closed;
-    marketplaceReindexState.auctions[auctionIndex].modifiedDate = modifiedDate;
+    auction.status = AuctionStatusEnum.Closed;
+    auction.modifiedDate = modifiedDate;
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-offer-accepted.handler.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-offer-accepted.handler.ts
@@ -13,10 +13,10 @@ export class ReindexOfferAcceptedHandler {
   handle(marketplaceReindexState: MarketplaceReindexState, input: OfferAcceptedSummary): void {
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
     const offerIndex = marketplaceReindexState.getOfferIndexByOfferId(input.offerId);
-    const auctionIndex =
+    const auction =
       marketplaceReindexState.marketplace.key !== ELRONDNFTSWAP_KEY
-        ? marketplaceReindexState.getAuctionIndexByAuctionId(input.auctionId)
-        : marketplaceReindexState.getAuctionIndexByIdentifier(input.identifier);
+        ? marketplaceReindexState.auctionMap.get(input.auctionId)
+        : marketplaceReindexState.auctionMap.get(input.auctionId); //de scris
 
     if (offerIndex !== -1) {
       marketplaceReindexState.offers[offerIndex].status = OfferStatusEnum.Accepted;
@@ -24,9 +24,9 @@ export class ReindexOfferAcceptedHandler {
       return;
     }
 
-    if (auctionIndex !== -1) {
-      marketplaceReindexState.auctions[auctionIndex].status = AuctionStatusEnum.Closed;
-      marketplaceReindexState.auctions[auctionIndex].modifiedDate = modifiedDate;
+    if (auction) {
+      auction.status = AuctionStatusEnum.Closed;
+      auction.modifiedDate = modifiedDate;
     }
   }
 }

--- a/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-offer-created.hander.ts
+++ b/src/modules/marketplaces/marketplaces-reindex-handlers/reindex-offer-created.hander.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import BigNumber from 'bignumber.js';
 import { constants } from 'src/config';
 import { OfferEntity } from 'src/db/offers';
 import { OfferStatusEnum } from 'src/modules/offers/models';
@@ -14,8 +15,11 @@ export class ReindexOfferCreatedHandler {
   handle(marketplaceReindexState: MarketplaceReindexState, input: OfferCreatedSummary, decimals: number): void {
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
     const priceAmountDenominated = BigNumberUtils.denominateAmount(input.price, decimals);
+
+    marketplaceReindexState.deleteOfferIfDuplicates(input.offerId);
+
     const offer = new OfferEntity({
-      id: marketplaceReindexState.offers.length,
+      id: marketplaceReindexState.getNewOfferId(),
       creationDate: modifiedDate,
       modifiedDate,
       marketplaceOfferId: input.offerId,
@@ -24,7 +28,7 @@ export class ReindexOfferCreatedHandler {
       identifier: input.identifier,
       priceToken: input.paymentToken,
       priceNonce: input.paymentNonce,
-      priceAmount: input.price,
+      priceAmount: new BigNumber(input.price).toFixed(),
       priceAmountDenominated: Math.min(priceAmountDenominated, constants.dbMaxDenominatedValue),
       ownerAddress: input.address,
       endDate: Math.min(input.endTime, constants.dbMaxTimestamp),

--- a/src/modules/marketplaces/marketplaces-reindex.service.ts
+++ b/src/modules/marketplaces/marketplaces-reindex.service.ts
@@ -455,7 +455,7 @@ export class MarketplacesReindexService {
 
         marketplaceReindexState.isFullStateInMemory = false;
 
-        await this.populateAuctionMissingAssetTags(inactiveAuctions);
+        // await this.populateAuctionMissingAssetTags(inactiveAuctions);
 
         for (let i = 0; i < inactiveOrders.length; i++) {
           if (inactiveOrders[i].auctionId < 0) {
@@ -496,7 +496,7 @@ export class MarketplacesReindexService {
           });
         });
 
-        const saveTagsPromise = this.persistenceService.saveTagsOrIgnore(tags);
+        // const saveTagsPromise = this.persistenceService.saveTagsOrIgnore(tags);
 
         // for (let i = 0; i < inactiveOrders.length; i++) {
         //   if (inactiveOrders[i].auctionId < 0) {
@@ -522,8 +522,8 @@ export class MarketplacesReindexService {
         console.log({ orders: inactiveOrders.length, auctions: inactiveAuctions.length, offers: inactiveOffers.length });
 
         await Promise.all([
-          saveTagsPromise,
-          this.persistenceService.saveBulkOrdersOrUpdateAndFillId(inactiveOrders),
+          // saveTagsPromise,
+          // this.persistenceService.saveBulkOrdersOrUpdateAndFillId(inactiveOrders),
           this.persistenceService.saveBulkOffersOrUpdateAndFillId(inactiveOffers),
         ]);
       }
@@ -544,7 +544,6 @@ export class MarketplacesReindexService {
         ),
       ];
       const assets = await this.mxApiService.getNftsByIdentifiers(assetsWithNoTagsIdentifiers, 0, 'fields=identifier,tags');
-      const tags = assets.filter((a) => a.tags);
       for (let j = 0; j < assets?.length; j++) {
         auctions.filter((a) => a.identifier === assets[j].identifier).map((a) => (a.tags = assets[j]?.tags?.join(',') ?? ''));
       }

--- a/src/modules/marketplaces/marketplaces-reindex.service.ts
+++ b/src/modules/marketplaces/marketplaces-reindex.service.ts
@@ -480,21 +480,21 @@ export class MarketplacesReindexService {
 
         await this.auctionSetterService.saveBulkAuctionsOrUpdateAndFillId(inactiveAuctions);
 
-        let tags: TagEntity[] = [];
-        inactiveAuctions.map((auction) => {
-          const assetTags = auction.tags.split(',');
-          assetTags.map((assetTag) => {
-            if (assetTag !== '') {
-              tags.push(
-                new TagEntity({
-                  auctionId: auction.id,
-                  tag: assetTag.trim().slice(0, constants.dbMaxTagLength),
-                  auction: auction,
-                }),
-              );
-            }
-          });
-        });
+        // let tags: TagEntity[] = [];
+        // inactiveAuctions.map((auction) => {
+        //   const assetTags = auction.tags.split(',');
+        //   assetTags.map((assetTag) => {
+        //     if (assetTag !== '') {
+        //       tags.push(
+        //         new TagEntity({
+        //           auctionId: auction.id,
+        //           tag: assetTag.trim().slice(0, constants.dbMaxTagLength),
+        //           auction: auction,
+        //         }),
+        //       );
+        //     }
+        //   });
+        // });
 
         // const saveTagsPromise = this.persistenceService.saveTagsOrIgnore(tags);
 

--- a/src/modules/marketplaces/marketplaces.module.ts
+++ b/src/modules/marketplaces/marketplaces.module.ts
@@ -26,6 +26,7 @@ import { ReindexAuctionPriceUpdatedHandler } from './marketplaces-reindex-handle
 import { ReindexGlobalOfferAcceptedHandler } from './marketplaces-reindex-handlers/reindex-global-offer-accepted.handler';
 import { ReindexAuctionUpdatedHandler } from './marketplaces-reindex-handlers/reindex-auction-updated.handler';
 import { MarketplacesMutationsResolver } from './marketplaces-mutations.resolver';
+import { OrdersModuleGraph } from '../orders/orders.module';
 
 @Module({
   providers: [
@@ -58,6 +59,7 @@ import { MarketplacesMutationsResolver } from './marketplaces-mutations.resolver
     MxCommunicationModule,
     forwardRef(() => CommonModule),
     forwardRef(() => AuctionsModuleGraph),
+    forwardRef(() => OrdersModuleGraph),
     forwardRef(() => OffersModuleGraph),
   ],
   exports: [MarketplacesService, MarketplaceEventsIndexingService, MarketplacesReindexService],

--- a/src/modules/marketplaces/models/MarketplaceReindexState.ts
+++ b/src/modules/marketplaces/models/MarketplaceReindexState.ts
@@ -52,7 +52,6 @@ export class MarketplaceReindexState {
     const modifiedDate = DateUtils.getUtcDateFromTimestamp(input.timestamp);
     const price = input.price ?? input.currentBid;
     return new OrderEntity({
-      id: this.getNewOrderId(),
       creationDate: modifiedDate,
       modifiedDate,
       ownerAddress: input.address,

--- a/src/modules/marketplaces/models/MarketplaceReindexState.ts
+++ b/src/modules/marketplaces/models/MarketplaceReindexState.ts
@@ -118,6 +118,9 @@ export class MarketplaceReindexState {
   }
 
   public updateAuctionStatus(auction: AuctionEntity, blockHash: string, status: AuctionStatusEnum, timestamp: number): void {
+    if (auction.endDate > 0 && auction.endDate <= DateUtils.getCurrentTimestamp()) {
+      status = AuctionStatusEnum.Claimable;
+    }
     auction.status = status;
     auction.blockHash = auction.blockHash ?? blockHash;
     auction.modifiedDate = DateUtils.getUtcDateFromTimestamp(timestamp);

--- a/src/modules/marketplaces/models/MarketplaceReindexState.ts
+++ b/src/modules/marketplaces/models/MarketplaceReindexState.ts
@@ -118,9 +118,6 @@ export class MarketplaceReindexState {
   }
 
   public updateAuctionStatus(auction: AuctionEntity, blockHash: string, status: AuctionStatusEnum, timestamp: number): void {
-    if (auction.endDate > 0 && auction.endDate <= DateUtils.getCurrentTimestamp()) {
-      status = AuctionStatusEnum.Claimable;
-    }
     auction.status = status;
     auction.blockHash = auction.blockHash ?? blockHash;
     auction.modifiedDate = DateUtils.getUtcDateFromTimestamp(timestamp);

--- a/src/modules/marketplaces/models/MarketplaceReindexState.ts
+++ b/src/modules/marketplaces/models/MarketplaceReindexState.ts
@@ -118,14 +118,9 @@ export class MarketplaceReindexState {
   }
 
   public updateAuctionStatus(auction: AuctionEntity, blockHash: string, status: AuctionStatusEnum, timestamp: number): void {
-    const updatedAuction = {
-      ...auction,
-      status,
-      blockHash: auction.blockHash ?? blockHash,
-      modifiedDate: DateUtils.getUtcDateFromTimestamp(timestamp),
-    };
-
-    this.auctionMap[auction.marketplaceAuctionId] = updatedAuction;
+    auction.status = status;
+    auction.blockHash = auction.blockHash ?? blockHash;
+    auction.modifiedDate = DateUtils.getUtcDateFromTimestamp(timestamp);
   }
 
   deleteOfferIfDuplicates(marketplaceOfferId: number) {

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -37,7 +37,7 @@ export class NotificationsService {
 
   async generateNotifications(auctions: AuctionEntity[]): Promise<void> {
     await this.updateNotificationStatus(auctions?.map((a) => a.id));
-    const orders = await this.ordersService.getOrdersByAuctionIds(auctions?.map((a) => a.id));
+    const orders = await this.ordersService.getOrdersByAuctionIdsGroupByAuctionId(auctions?.map((a) => a.id));
     for (const auction of auctions) {
       this.addNotifications(auction, orders[auction.id]);
     }

--- a/src/modules/orders/order.service.ts
+++ b/src/modules/orders/order.service.ts
@@ -146,6 +146,18 @@ export class OrdersService {
     return this.ordersCachingService.getOrSetOrders(queryRequest, () => this.getMappedOrders(queryRequest));
   }
 
+  async getOrdersByAuctionIdsGroupByAuctionId(
+    auctionIds: number[],
+  ): Promise<OrderEntity[]> {
+    if (auctionIds?.length > 0) {
+      const orders =
+        await this.persistenceService.getOrdersByAuctionIdsGroupByAuctionId(
+          auctionIds,
+        );
+      return orders;
+    }
+  }
+
   async getOrdersByAuctionIds(auctionIds: number[]): Promise<OrderEntity[]> {
     if (auctionIds?.length > 0) {
       const orders = await this.persistenceService.getOrdersByAuctionIds(auctionIds);


### PR DESCRIPTION
- hybrid/partial reindex states (Partial items from marketplaceReindexState can be in DB and some in Memory, without any problems)

PS:
1) there are few places where the code is a bit complicated, because it's hard to find corresponding Auctions for Orders, or corresponding in memory Orders for DB Orders :cry: ; Solution: also add `marketplaceAuctionId` column in orders table, or create `marketplaceOrderId` in SC & table.
2) the items' IDs have negative values by default (e.g. `auctionsTemporaryIdCounter = -1`), so it ca be easier to find out if an item was saved in DB or is just in memory