### PR TITLE
fix bigInt nonce conversion

### DIFF
--- a/src/modules/assets/assets-transaction.service.ts
+++ b/src/modules/assets/assets-transaction.service.ts
@@ -94,7 +94,8 @@ export class AssetsTransactionService {
   async transferNft(ownerAddress: string, transferRequest: TransferNftRequest): Promise<TransactionNode> {
     const { collection, nonce } = getCollectionAndNonceFromIdentifier(transferRequest.identifier);
 
-    const nft = new Token({ identifier: collection, nonce: BigInt(nonce) });
+    const nonceDecimal = BigInt(parseInt(nonce, 16));
+    const nft = new Token({ identifier: collection, nonce: nonceDecimal });
     const transfer = new TokenTransfer({ token: nft, amount: BigInt(transferRequest.quantity) });
     const factory = new TransferTransactionsFactory({ config: new TransactionsFactoryConfig({ chainID: mxConfig.chainID }) });
     const transaction = factory.createTransactionForTransfer(Address.newFromBech32(ownerAddress), {


### PR DESCRIPTION
Issue:
* nfts transfers were failing for tokens with large hexadecimal nonces (e.g., MADCAPS-9e876f-0435, JOKER-753c62-01f6) due to incorrect BigInt conversion from hex strings.

Fix:
* added proper hexadecimal to decimal conversion before BigInt creation:

added new tests to validate this fix